### PR TITLE
chore: bump the footer copyright year to 2026

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -17,7 +17,7 @@ export default function Footer() {
                     <Spacer />
                     <span>e3liang [at] stanford [dot] edu</span>
                 </div>
-                <div>c 2025</div>
+                <div>c 2026</div>
             </div>
         </div>
     )


### PR DESCRIPTION
The footer still read `c 2025`.

```diff
-                <div>c 2025</div>
+                <div>c 2026</div>
```

One line, one file. Left as a literal rather than `new Date().getFullYear()` on purpose: every page here is prerendered at build time, so a computed year would freeze at whatever year the last deploy happened in and then disagree with the client on New Year's Day — a hydration mismatch that is strictly worse than editing one line annually.

Draft, as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)