### PR TITLE
feat(credits): hold the crawl while text is selected

### DIFF
--- a/pages/credits.js
+++ b/pages/credits.js
@@ -45,7 +45,8 @@ export default function Credits() {
         splashObserver.observe(document.querySelector("#splashplaceholder"));
 
         // The credits crawl upward on their own, pausing for a second after any
-        // user scroll and for as long as a mouse button is held.
+        // user scroll, for as long as a mouse button is held, and for as long
+        // as any text stays selected.
         //
         // Driven off the frame clock, with each step derived from elapsed time:
         // that keeps the on-screen speed independent of frame rate, costs one
@@ -55,6 +56,7 @@ export default function Credits() {
 
         let lastScrollAt = Number.NEGATIVE_INFINITY; // so the crawl starts at once
         let locked = false;
+        let selecting = false;
         let carry = 0;
         let previousFrame = null;
         let frameId;
@@ -68,7 +70,7 @@ export default function Credits() {
             previousFrame = now;
             if (previous === null) return;
 
-            if (locked || now - lastScrollAt <= 1000) {
+            if (locked || selecting || now - lastScrollAt <= 1000) {
                 carry = 0;
                 return;
             }
@@ -97,10 +99,18 @@ export default function Credits() {
             locked = false;
             noteUserScroll();
         }
+        function onSelectionChange() {
+            // Ranges that render as nothing do not count as a selection.
+            const selection = document.getSelection();
+            selecting = selection !== null
+                && !selection.isCollapsed
+                && selection.toString().trim() !== '';
+        }
 
         window.addEventListener('wheel', noteUserScroll);
         window.addEventListener('mousedown', onMouseDown);
         window.addEventListener('mouseup', onMouseUp);
+        document.addEventListener('selectionchange', onSelectionChange);
 
         frameId = requestAnimationFrame(step);
 
@@ -111,6 +121,7 @@ export default function Credits() {
             window.removeEventListener('wheel', noteUserScroll);
             window.removeEventListener('mousedown', onMouseDown);
             window.removeEventListener('mouseup', onMouseUp);
+            document.removeEventListener('selectionchange', onSelectionChange);
             splashObserver.disconnect();
         };
     }, []);


### PR DESCRIPTION
Highlighting a name on the credits page bought you the one-second pause that follows any interaction, and then the crawl carried your selection up and off the screen. Now it waits as long as the selection stands.

## The change

One flag, fed by `selectionchange`, joining the two conditions that already stop the crawl:

```diff
-            if (locked || now - lastScrollAt <= 1000) {
+            if (locked || selecting || now - lastScrollAt <= 1000) {
```

```js
function onSelectionChange() {
    // Empty and whitespace-only ranges are ignored: a click that lands
    // between two elements can leave a selection that renders as
    // nothing, and that must not freeze the page with no visible cause.
    const selection = document.getSelection();
    selecting = selection !== null
        && !selection.isCollapsed
        && selection.toString().trim() !== '';
}
```

Two notes on the approach:

- **Event-driven, not polled.** The obvious alternative is to read `getSelection()` inside `step()`, but that runs `toString()` on every painted frame — on a Ctrl+A over 686 names that is a multi-kilobyte allocation 60 times a second. `selectionchange` fires only when the selection actually moves.
- **The whitespace guard is the important half.** Without it a click landing between two elements can leave a non-collapsed range containing no visible text, and the page would sit frozen with nothing on screen to explain why. Freezing now corresponds exactly to "you can see something highlighted."

Clearing the selection needs no special handling: the click that clears it already goes through `mouseup → noteUserScroll()`, which grants the usual one-second grace before the crawl picks up.

## Verification

Measured in the browser against the real page, sampling `scrollTop` over fixed intervals:

| | scrolled |
|---|---|
| idle | 114 px/s |
| while `"JACK P"` selected | **0 px** over 1.5 s |
| after clearing | 116 px/s |
| 48-char selection across six names | **0 px** over 1.2 s |
| range over empty content (`isCollapsed: true`, text `""`) | 114 px/s — correctly ignored |

Listener teardown checked too, since this adds one to `document` rather than `window`. After a client-side round trip to `/portfolio` and back, the crawl runs at 114 px/s — unchanged, so nothing leaked — and the freeze still works.

`npm run build` and `eslint` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)