### PR TITLE
fix(lint): ignore generated output and nested checkouts at any depth

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,13 @@ import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
 
 const config = [
   {
-    ignores: ['.next/**', 'out/**', 'build/**', 'node_modules/**'],
+    ignores: [
+      '**/.next/**',
+      '**/out/**',
+      '**/build/**',
+      '**/node_modules/**',
+      '.claude/**',
+    ],
   },
   ...nextCoreWebVitals,
 ]


### PR DESCRIPTION
`npm run lint` currently fails with 465 errors, none of them in this repo's source.

## Cause

Flat-config `ignores` patterns resolve against the config file's directory, so `'.next/**'` is anchored at the repo root and matches only the build output sitting there. Any nested copy is invisible to it and gets linted as ordinary source.

A git worktree under `.claude/` is exactly that: it carries its own `.next`, *and* a complete checkout of the tree. Measured on the working copy:

```
files linted total      : 128
  under .claude/         : 114
    build output (.next) : 100     ← all 465 errors live here
    real source          :  14     ← another branch's source, this branch's config
  own source             :  14
```

So two distinct problems: unlintable generated chunks producing the errors, and a second branch's source being linted against the wrong config — silently doubling the surface even once the noise is gone.

## Fix

```diff
-    ignores: ['.next/**', 'out/**', 'build/**', 'node_modules/**'],
+    ignores: [
+      '**/.next/**',
+      '**/out/**',
+      '**/build/**',
+      '**/node_modules/**',
+      '.claude/**',
+    ],
```

`**/` covers generated output wherever it sits, which is the general form of the bug rather than a patch for the one directory that happened to trip it. `.claude/**` is separate and deliberate: a worktree there is a separate checkout with its own `eslint.config.mjs`, and it should lint itself.

## Verification

```
$ npm run lint
exit 0

files linted total      : 14
  under .claude/         :  0
  own source             : 14
errors total            :  0
```

Those 14 are exactly the 14 files `git ls-files '*.js' '*.mjs'` reports, so the broader ignores exclude nothing real:

```
components/footer.js          pages/_app.js
components/gallery/gallery_collection.js   pages/_document.js
components/navbar.js          pages/credits.js
components/spacer.js          pages/index.js
data/credits.js               pages/palette.js
eslint.config.mjs             pages/portfolio.js
next.config.js                util/fonts.js
```

CI is unaffected either way — `.claude/` is untracked, so this only ever bit local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)