### PR TITLE
feat(credits): latch the crawl off and offer a play button

### DIFF
--- a/pages/credits.js
+++ b/pages/credits.js
@@ -3,10 +3,10 @@ import Image from 'next/image';
 
 import style from '../styles/credits.module.css'
 import yourname from '../public/credits.png'
-import { motion } from 'framer-motion';
-import OverlayScrollbars from 'overlayscrollbars';
+import { AnimatePresence, motion } from 'framer-motion';
 import { opensans } from '../util/fonts';
 import { rows } from '../data/credits';
+import useCrawl from '../util/usecrawl';
 
 // One block of names. The label column stays in the markup even when empty so
 // that every block lines up on the same centre seam.
@@ -33,6 +33,7 @@ function Group({ label, blocks }) {
 
 export default function Credits() {
     const [opacity, setOpacity] = useState(0);
+    const { paused, resume } = useCrawl();
 
     useEffect(() => {
         // The splash art fades in proportion to how much of the placeholder at
@@ -44,86 +45,7 @@ export default function Credits() {
         }, { threshold: Array.from({ length: 101 }, (x, i) => i / 100) });
         splashObserver.observe(document.querySelector("#splashplaceholder"));
 
-        // The credits crawl upward on their own, pausing for a second after any
-        // user scroll, for as long as a mouse button is held, and for as long
-        // as any text stays selected.
-        //
-        // Driven off the frame clock, with each step derived from elapsed time:
-        // that keeps the on-screen speed independent of frame rate, costs one
-        // callback per painted frame, and stops the crawl automatically while
-        // the tab is backgrounded.
-        const PIXELS_PER_SECOND = 100;
-
-        let lastScrollAt = Number.NEGATIVE_INFINITY; // so the crawl starts at once
-        let locked = false;
-        let selecting = false;
-        let carry = 0;
-        let previousFrame = null;
-        let frameId;
-
-        let scroller = OverlayScrollbars(document.querySelector("body"));
-
-        function step(now) {
-            frameId = requestAnimationFrame(step);
-
-            const previous = previousFrame;
-            previousFrame = now;
-            if (previous === null) return;
-
-            if (locked || selecting || now - lastScrollAt <= 1000) {
-                carry = 0;
-                return;
-            }
-
-            if (scroller === undefined) {
-                scroller = OverlayScrollbars(document.querySelector("body"));
-            }
-
-            // Accumulate fractional pixels so speed does not depend on frame
-            // rate, and scroll only whole ones.
-            carry += ((now - previous) / 1000) * PIXELS_PER_SECOND;
-            const pixels = Math.floor(carry);
-            if (pixels >= 1) {
-                carry -= pixels;
-                scroller.scroll({ y: `+=${pixels}` });
-            }
-        }
-
-        function noteUserScroll() {
-            lastScrollAt = performance.now();
-        }
-        function onMouseDown() {
-            locked = true;
-        }
-        function onMouseUp() {
-            locked = false;
-            noteUserScroll();
-        }
-        function onSelectionChange() {
-            // Ranges that render as nothing do not count as a selection.
-            const selection = document.getSelection();
-            selecting = selection !== null
-                && !selection.isCollapsed
-                && selection.toString().trim() !== '';
-        }
-
-        window.addEventListener('wheel', noteUserScroll);
-        window.addEventListener('mousedown', onMouseDown);
-        window.addEventListener('mouseup', onMouseUp);
-        document.addEventListener('selectionchange', onSelectionChange);
-
-        frameId = requestAnimationFrame(step);
-
-        // This route unmounts on every navigation away, so everything attached
-        // to window or observing a node has to come back off here.
-        return () => {
-            cancelAnimationFrame(frameId);
-            window.removeEventListener('wheel', noteUserScroll);
-            window.removeEventListener('mousedown', onMouseDown);
-            window.removeEventListener('mouseup', onMouseUp);
-            document.removeEventListener('selectionchange', onSelectionChange);
-            splashObserver.disconnect();
-        };
+        return () => splashObserver.disconnect();
     }, []);
 
     return (
@@ -160,6 +82,22 @@ export default function Credits() {
                     </div>
                 </motion.div>
             </div>
+            <AnimatePresence>
+                {paused &&
+                    <motion.button
+                        className={style.resume}
+                        onClick={resume}
+                        aria-label="Resume the credits"
+                        initial={{ opacity: 0, scale: 0.8 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.8 }}
+                        transition={{ duration: 0.15 }}>
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M9 6.5 18 12l-9 5.5z" />
+                        </svg>
+                    </motion.button>
+                }
+            </AnimatePresence>
         </div>
     )
 

--- a/styles/credits.module.css
+++ b/styles/credits.module.css
@@ -132,3 +132,34 @@
     margin-top: 80vh;
     height: 20vh;
 }
+
+.resume {
+    position: fixed;
+    right: 2rem;
+    bottom: 2rem;
+    z-index: 2;
+
+    width: 4.5rem;
+    height: 4.5rem;
+
+    display: grid;
+    place-items: center;
+
+    border: 1px solid var(--borders);
+    border-radius: 50%;
+    background-color: var(--back);
+    color: var(--primary);
+
+    cursor: pointer;
+}
+
+.resume:hover {
+    border-color: var(--primary);
+}
+
+.resume svg {
+    width: 2rem;
+    height: 2rem;
+
+    fill: currentColor;
+}

--- a/util/usecrawl.js
+++ b/util/usecrawl.js
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import OverlayScrollbars from 'overlayscrollbars';
+
+const PIXELS_PER_SECOND = 100;
+
+// Keys the browser scrolls with. Space is left out: it reaches this handler
+// from the resume button too, where it means "press", not "scroll".
+const SCROLL_KEYS = new Set([
+    'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End',
+]);
+
+const REDUCED_MOTION = '(prefers-reduced-motion: reduce)';
+
+// The server has no media queries to read, so it renders as if motion were
+// welcome and the subscription corrects it on hydration.
+function useReducedMotion() {
+    return useSyncExternalStore(
+        (onChange) => {
+            const query = window.matchMedia(REDUCED_MOTION);
+            query.addEventListener('change', onChange);
+            return () => query.removeEventListener('change', onChange);
+        },
+        () => window.matchMedia(REDUCED_MOTION).matches,
+        () => false,
+    );
+}
+
+// Scrolls the page upward on its own. Scroll input, a scrollbar drag, or
+// leaving the tab latch it off until resume(); a held mouse button or a live
+// selection stop it only while they last. Until the first latch, reduced
+// motion decides. `paused` reports the latch, minus the foot of the page,
+// where there is nothing left to resume.
+export default function useCrawl() {
+    const [latched, setLatched] = useState(null);
+    const [ended, setEnded] = useState(false);
+    const reduced = useReducedMotion();
+
+    const stopped = latched ?? reduced;
+    const latchedNow = useRef(false);
+    useEffect(() => {
+        latchedNow.current = stopped;
+    }, [stopped]);
+
+    const resume = useCallback(() => {
+        document.getSelection()?.removeAllRanges();
+        setLatched(false);
+    }, []);
+
+    useEffect(() => {
+        let locked = false;
+        let selecting = false;
+        let heldAt = null;
+        let wasAtEnd = false;
+        let carry = 0;
+        let previousFrame = null;
+        let frameId;
+
+        let scroller = OverlayScrollbars(document.querySelector("body"));
+        const position = () => scroller?.scroll().position.y;
+        const atEnd = () => scroller?.scroll().ratio.y >= 1;
+
+        function step(now) {
+            frameId = requestAnimationFrame(step);
+
+            const previous = previousFrame;
+            previousFrame = now;
+            if (previous === null) return;
+
+            // Nothing left to resume once the crawl has run out of page.
+            if (atEnd() !== wasAtEnd) {
+                wasAtEnd = !wasAtEnd;
+                setEnded(wasAtEnd);
+            }
+
+            if (latchedNow.current || locked || selecting) {
+                carry = 0;
+                return;
+            }
+
+            if (scroller === undefined) {
+                scroller = OverlayScrollbars(document.querySelector("body"));
+            }
+
+            // Accumulate fractional pixels so speed does not depend on frame
+            // rate, and scroll only whole ones.
+            carry += ((now - previous) / 1000) * PIXELS_PER_SECOND;
+            const pixels = Math.floor(carry);
+            if (pixels >= 1) {
+                carry -= pixels;
+                scroller.scroll({ y: `+=${pixels}` });
+            }
+        }
+
+        function onWheel() {
+            setLatched(true);
+        }
+        function onTouchMove() {
+            setLatched(true);
+        }
+        function onKeyDown(event) {
+            if (SCROLL_KEYS.has(event.key)) setLatched(true);
+        }
+        function onMouseDown() {
+            locked = true;
+            heldAt = position() ?? null;
+        }
+        function onMouseUp() {
+            locked = false;
+            // Dragging the scrollbar moves the page without firing any of the
+            // events above, so the position is what gives it away.
+            if (heldAt !== null && position() !== heldAt) setLatched(true);
+            heldAt = null;
+        }
+        function onSelectionChange() {
+            // Ranges that render as nothing do not count as a selection.
+            const selection = document.getSelection();
+            selecting = selection !== null
+                && !selection.isCollapsed
+                && selection.toString().trim() !== '';
+        }
+        function onLeave() {
+            setLatched(true);
+        }
+
+        window.addEventListener('wheel', onWheel);
+        window.addEventListener('touchmove', onTouchMove);
+        window.addEventListener('keydown', onKeyDown);
+        window.addEventListener('mousedown', onMouseDown);
+        window.addEventListener('mouseup', onMouseUp);
+        window.addEventListener('blur', onLeave);
+        document.addEventListener('selectionchange', onSelectionChange);
+        document.addEventListener('visibilitychange', onLeave);
+
+        frameId = requestAnimationFrame(step);
+
+        // This route unmounts on every navigation away, so everything attached
+        // to window or document has to come back off here.
+        return () => {
+            cancelAnimationFrame(frameId);
+            window.removeEventListener('wheel', onWheel);
+            window.removeEventListener('touchmove', onTouchMove);
+            window.removeEventListener('keydown', onKeyDown);
+            window.removeEventListener('mousedown', onMouseDown);
+            window.removeEventListener('mouseup', onMouseUp);
+            window.removeEventListener('blur', onLeave);
+            document.removeEventListener('selectionchange', onSelectionChange);
+            document.removeEventListener('visibilitychange', onLeave);
+        };
+    }, []);
+
+    return { paused: stopped && !ended, resume };
+}


### PR DESCRIPTION
The credits crawl used to resume a second after you scrolled, so reading anything meant fighting it. Now a pause is a state you leave deliberately.

**Latched** — stays stopped until the button is pressed:
- wheel / touchmove / arrow, page, home, end keys
- a scrollbar drag (detected by position change across a mouse hold, since dragging fires none of the events above)
- leaving the tab (`blur`, `visibilitychange`)

**Transient** — only lasts as long as it does:
- a held mouse button
- a live selection: deselecting resumes on its own, and pressing play clears the selection

The button renders only while latched, so it does not flicker under a mouse hold or a selection, and it hides at the foot of the page where there is nothing left to resume. `prefers-reduced-motion: reduce` decides the starting state, read through `useSyncExternalStore` so the server and the first client render agree.

The crawl moves out of `pages/credits.js` into `util/usecrawl.js`, leaving the page with the splash observer and the markup.

Verified against a production build in Chrome:

| behavior | result |
|---|---|
| crawls on load, no button | 91 px/s, no button |
| wheel latches | button appears, 0 px over 700 ms |
| play resumes and clears the selection | selection empty, motion resumes |
| selection holds, deselect resumes | 0 px held, moves again on deselect |
| scroll key latches | button appears |
| tab-out latches | button appears, 0 px |
| foot of page | button hidden |
| route away and back | 114 px/s, no doubled loop |

`npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)